### PR TITLE
BUG-FIX: Return All Gists/Results for User

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,6 +12,7 @@ module.exports = {
     'no-console': 0,
     '@typescript-eslint/explicit-member-accessibility': 0,
     '@typescript-eslint/explicit-function-return-type': 0,
-    '@typescript-eslint/consistent-type-definitions': ['error', 'type']
+    '@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+    '@typescript-eslint/no-explicit-any': 0
   }
 };

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,6 @@
 import { Octokit } from '@octokit/core';
+import { paginateRest } from '@octokit/plugin-paginate-rest';
+import { restEndpointMethods } from '@octokit/plugin-rest-endpoint-methods';
 import chalk from 'chalk';
 import figlet from 'figlet';
 import yargs from 'yargs';
@@ -10,7 +12,7 @@ type run = {
   UserName: string;
   LastRunTimeStamp: string;
 };
-const defaultUser = 'takakabe';
+const defaultUser = 'djsd123';
 const timeNow = new Date(Date.now()).toISOString();
 
 const options = yargs(hideBin(process.argv))
@@ -43,37 +45,142 @@ switch (os.platform()) {
     filePath = `${process.env.HOME}/lastRUN`;
 }
 
-const client = new Octokit({});
+/*
+  Load plugins into Ocktokit for pagination and helper methods.
+  https://github.com/octokit/plugin-paginate-rest.js
+  https://github.com/octokit/plugin-rest-endpoint-methods.js/blob/master/docs/gists/listForUser.md
+*/
+const OcktokitWithPagination = Octokit.plugin(
+  paginateRest,
+  restEndpointMethods
+);
+const client = new OcktokitWithPagination({});
+const listForUserMethod = client.rest.gists.listForUser;
 
-const getGists = async (user: string, time?: string) => {
-  await client
-    .request('GET /users/{username}/gists', {
-      username: user,
-      since: time,
-    })
-    .then((result) => {
-      console.log(
-        chalk.cyan(
-          figlet.textSync(user, {
-            horizontalLayout: 'default',
-            font: 'Colossal',
-          })
-        )
-      );
-      result.data.forEach((gist) =>
-        console.log(
-          chalk.magentaBright('Created: ') +
-            new Date(gist.created_at).toDateString() +
-            chalk.cyan(','),
-          chalk.green('URL: ') + gist.html_url + chalk.cyan(','),
-          chalk.yellow('Description: ') + gist.description
-        )
-      );
-      return;
-    })
-    .catch((error) => console.log(error));
+let printName = (user: string) => {
+  console.log(
+    chalk.cyan(
+      figlet.textSync(user, {
+        horizontalLayout: 'default',
+        font: 'Colossal',
+      })
+    )
+  );
+  /*
+    Pagination result indices always reset to 0 for each page of results/gists.
+    I only want to call this **printName** function ONCE at the top of the first page and want to do it
+    only once I have retrieved the first page of results successfully.
+
+    This is why below I am assigning the **printName** function to a noop function, so on subsequent calls
+    to the **printName** function. Nothing happens. See: https://stackoverflow.com/a/72992927/2719085
+  */
+  printName = () => {
+    // NooP
+  };
 };
 
+/*
+  gist: Type auto generated
+*/
+const printGist = (gist: {
+  url?: string;
+  forks_url?: string;
+  commits_url?: string;
+  id?: string;
+  node_id?: string;
+  git_pull_url?: string;
+  git_push_url?: string;
+  html_url: any;
+  files?: {
+    [key: string]: {
+      filename?: string | undefined;
+      type?: string | undefined;
+      language?: string | undefined;
+      raw_url?: string | undefined;
+      size?: number | undefined;
+    };
+  };
+  public?: boolean;
+  created_at: any;
+  updated_at?: string;
+  description: any;
+  comments?: number;
+  user?: {
+    name?: string | null | undefined;
+    email?: string | null | undefined;
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string | null;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    site_admin: boolean;
+    starred_at?: string | undefined;
+  } | null;
+  comments_url?: string;
+  owner?:
+    | {
+        name?: string | null | undefined;
+        email?: string | null | undefined;
+        login: string;
+        id: number;
+        node_id: string;
+        avatar_url: string;
+        gravatar_id: string | null;
+        url: string;
+        html_url: string;
+        followers_url: string;
+        following_url: string;
+        gists_url: string;
+        starred_url: string;
+        subscriptions_url: string;
+        organizations_url: string;
+        repos_url: string;
+        events_url: string;
+        received_events_url: string;
+        type: string;
+        site_admin: boolean;
+        starred_at?: string | undefined;
+      }
+    | undefined;
+  truncated?: boolean | undefined;
+  forks?: unknown[] | undefined;
+  history?: unknown[] | undefined;
+}) => {
+  console.log(
+    chalk.magentaBright('Created: ') +
+      new Date(gist.created_at).toDateString() +
+      chalk.cyan(','),
+    chalk.green('URL: ') + gist.html_url + chalk.cyan(','),
+    chalk.yellow('Description: ') + gist.description
+  );
+};
+
+const getGists = async (user: string, time?: string) => {
+  for await (const results of client.paginate.iterator(listForUserMethod, {
+    username: user,
+    since: time,
+  })) {
+    results.data.forEach((gist, index) => {
+      index == 0 ? (printName(user), printGist(gist)) : printGist(gist);
+    });
+  }
+};
+
+/*
+  I use a JSON formatted file to store timestamps of previous runs for each user queried
+*/
 const runFileExists = (file: fs.PathLike) => {
   return fs.existsSync(file);
 };
@@ -96,6 +203,9 @@ const newEntry = (user: string, time: string, entries: run[]) => {
   return entries;
 };
 
+/*
+  The data in the file is always overwritten with in memory data
+*/
 const saveChanges = (file: fs.PathLike, fileContents: run[]) => {
   const json = JSON.stringify(fileContents);
   fs.appendFile(file, json, { flag: 'w+', encoding: 'utf8' }, (error) => {
@@ -106,6 +216,9 @@ const saveChanges = (file: fs.PathLike, fileContents: run[]) => {
   });
 };
 
+/*
+  This function is called when this utility doesn't find an existing run file
+*/
 const initialRun = (file: fs.PathLike, user: string, time: string) => {
   const entries: run[] = [];
   const rawEntry: run = {
@@ -117,24 +230,41 @@ const initialRun = (file: fs.PathLike, user: string, time: string) => {
   getGists(user).then();
 };
 
+/*
+  This function is called when this utility finds an existing run file
+*/
 const consecutiveRun = (file: fs.PathLike, user: string, time: string) => {
   const runData = loadRunFile(file);
   const matchIndex = runData.findIndex((runEntry) => runEntry.UserName == user);
+  /*
+    (matchIndex > -1) means if we find the user we're querying in the run file
+  */
   if (matchIndex > -1) {
     const updatedContent = updateRunEntry(time, runData, matchIndex);
     saveChanges(file, updatedContent);
+    /*
+      options.freshrun or -f (on the command line)
+      Means this utility will ignore the fact that there is a timestamp by
+      calling the **getGists** function without the optional timestamp parameter.
+    */
     options.freshrun ? getGists(user).then() : getGists(user, time).then();
   } else {
+    /*
+      if we don't find the user we're querying in the run file, then we
+      proceed with the below.
+      i.e. add the user and timestamp to the run file, then fetch their gists
+    */
     const newContent = newEntry(user, time, runData);
     saveChanges(file, newContent);
     getGists(user).then();
   }
 };
 
-// Check if run file exists
+/*
+  If this utility doesn't find a run file, then we call the **initialRun** function.
+  Otherwise, we call the **consecutiveRun** function upon finding an existing run file.
+*/
 
-if (runFileExists(filePath)) {
-  consecutiveRun(filePath, options.user, timeNow);
-} else {
-  initialRun(filePath, options.user, timeNow);
-}
+runFileExists(filePath)
+  ? consecutiveRun(filePath, options.user, timeNow)
+  : initialRun(filePath, options.user, timeNow);

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@octokit/core": "^3.6.0",
+    "@octokit/plugin-paginate-rest": "^2.20.0",
+    "@octokit/plugin-rest-endpoint-methods": "^5.16.0",
     "@types/figlet": "^1.5.4",
     "chalk": "^5.0.1",
     "figlet": "^1.5.2",
@@ -24,11 +26,11 @@
     "@types/yargs": "^17.0.10",
     "@typescript-eslint/eslint-plugin": "^5.27.0",
     "@typescript-eslint/parser": "^5.27.0",
-    "prettier": "^2.6.2",
     "eslint": "^8.16.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.0.0",
+    "prettier": "^2.6.2",
     "typescript": "^4.7.2"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -120,6 +120,26 @@
   resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
   integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
+"@octokit/openapi-types@^12.5.0":
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-12.5.0.tgz#e10b256237c877fa6f0a21922151dc03d9c57510"
+  integrity sha512-VatvE5wtRkJq6hAWGTBZ62WkrdlCiy0G0u27cVOYTfAWVZi7QqTurVcjpsyc5+9hXLPRP5O/DaNEs4TgAp4Mqg==
+
+"@octokit/plugin-paginate-rest@^2.20.0":
+  version "2.20.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.20.0.tgz#874f9d0cd500bfa0f0901a44de834e3de115d28b"
+  integrity sha512-LbemX86JEmOCFo9eRwrtdP5Isq69TefLS1J7w0DO4PMhfpvRfqYVzq9c0eH1xgcx2PSA7/VJHu9SwvNhD9FjVg==
+  dependencies:
+    "@octokit/types" "^6.38.1"
+
+"@octokit/plugin-rest-endpoint-methods@^5.16.0":
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.16.0.tgz#e0a774d78bb17fb9b6b9ae48d5517940f7f61e90"
+  integrity sha512-mvdwq+LvhR2GRDY82FgSZ52xX6wkOCpjiI3amiKbzKHd9nyKeFdXLsIQ3Go12tWRtvo+HwqoypLHDjRrgMFDQA==
+  dependencies:
+    "@octokit/types" "^6.38.0"
+    deprecation "^2.3.1"
+
 "@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
@@ -147,6 +167,13 @@
   integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
   dependencies:
     "@octokit/openapi-types" "^11.2.0"
+
+"@octokit/types@^6.38.0", "@octokit/types@^6.38.1":
+  version "6.38.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.38.1.tgz#03d70745564954dfdae32df23d5f1578f958474f"
+  integrity sha512-kWMohLCIvnwApRmxRFDOqve7puiNNdtVfgwdDOm6QyJNorWOgKv2/AodCcGqx63o28kF7Dr4/nJCatrwwqhULg==
+  dependencies:
+    "@octokit/openapi-types" "^12.5.0"
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.8"
@@ -478,7 +505,7 @@ define-properties@^1.1.3, define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-deprecation@^2.0.0:
+deprecation@^2.0.0, deprecation@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==


### PR DESCRIPTION
The utility was only returning one page of results/gists

Using this [Plugin](https://github.com/octokit/plugin-paginate-rest.js/) and it's **iterator** method I can print/retrieve all the gists/results a user has.

Also, split `getGists` into smaller pieces/functions such as `printName` which should only
be called once regardless of how many pages of results are returned.

- Add docstrings
- Change the default user variable from `takakabe` to `djsd123`

